### PR TITLE
Update dependency of pupa

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {
 		"ext-name": "^5.0.0",
-		"pupa": "^1.0.0",
+		"pupa": "^2.0.0",
 		"unused-filename": "^1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
To fix cross-site-scripting security issue, we need to upgrade pupa to 2.0.0 or higher. More details here -> https://github.com/sindresorhus/pupa/issues/4